### PR TITLE
Pkg json explicit versions + git initialization!

### DIFF
--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ const showHelp = require('./modules/showHelp')
 const noName = require('./modules/noName')
 const badName = require('./modules/badName')
 const portValidator = require('./modules/portValidator')
+const adjustPkgJson = require('./modules/adjustPkgJson')
 
 // Other.
 const cwd = process.cwd()
@@ -389,7 +390,7 @@ function createFiles(options) {
 }
 
 // STEP 5
-function installDependencies(options) {
+async function installDependencies(options) {
   const { appName, appDir, server, offline, redux, router } = options
   const forceOffline = offline ? ' --offline' : '' // https://goo.gl/aZLDLk
   const cache = offline ? ' cache' : ''
@@ -402,7 +403,17 @@ function installDependencies(options) {
   console.log(`Installing project dependencies via npm${cache}...\n`)
   run(`npm${forceOffline} i`)
 
+  // Adjust the package.json dependencies to show their installed version.
+  // E.x. - "react": "^16" => "react": "^16.6.1"
+  await adjustPkgJson(appDir)
 
+  // Initialize git.
+  try {
+    run('git init', true) // Don't display stdout.
+    console.log('Initialized a git repository.\n')
+  } catch (e) {}
+
+  // Display the final message.
   const cyanDir = chalk.cyan(appDir)
   const boldName = chalk.bold(appName)
   const serverMsg = server ? 'and Express servers' : 'server'

--- a/modules/adjustPkgJson.js
+++ b/modules/adjustPkgJson.js
@@ -1,0 +1,40 @@
+/*
+  Why this module?
+
+  Create New App manually creates a package.json file and fills in all the dependencies.
+  To use React as an example, we end up writing "react": "^16" to the file so we can get
+  the latest 16.x version of React. The problem is when you look at the package.json file,
+  you don't know which exact version was installed. It's much more helpful to see something
+  like ^16.6.1 instead.
+
+  This module will read package.json, distill the package names & versions down to an array,
+  read the actual versions of what's already been installed, and rewrite the file with the
+  actual versions, maintaining the ^ where applicable. This let's the user know what specific
+  versions of the packages are installed when they take a quick glance at package.json.
+*/
+
+const { exec } = require('child_process')
+const { readJsonSync, writeFileSync } = require('fs-extra')
+
+function adjustPkgJson(appDir) {
+  const packageJson = readJsonSync(`${appDir}/package.json`)
+  const deps = packageJson.dependencies
+  const devDeps = packageJson.devDependencies
+
+  deps && transformVersion(deps, appDir)
+  devDeps && transformVersion(devDeps, appDir)
+
+  const finalData = JSON.stringify(packageJson, null, 2)
+  writeFileSync(`${appDir}/package.json`, finalData, 'utf-8')
+}
+
+function transformVersion(obj, appDir) {
+  Object.keys(obj).forEach(key => {
+    const location = `${appDir}/node_modules/${key}/package.json`
+    const { version } = readJsonSync(location)
+
+    obj[key] = `^${version}`
+  })
+}
+
+module.exports = adjustPkgJson

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -93,9 +93,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "has-flag": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "chalk": "^2.4.1",
     "command-line-args": "^4.0.7",
-    "fs-extra": "^5.0.0",
+    "fs-extra": "^7.0.1",
     "validate-npm-package-name": "^3.0.0"
   },
   "engines": {


### PR DESCRIPTION
The generated package.json file will no longer contain version values such as `^16` or `latest`. I found myself relying on the package.json file to tell me explicitly what version of what packages were installed. This solves that problem.