### PR TITLE
Refactor error capture: server-owned, deep module, three-part schema

### DIFF
--- a/src/projects/fullstack/.claude-keep/skills/add-api-endpoint/SKILL.md
+++ b/src/projects/fullstack/.claude-keep/skills/add-api-endpoint/SKILL.md
@@ -76,7 +76,7 @@ Chain BEFORE `.notFound()` — order matters.
 
 ## Error Responses
 
-Every error path MUST return a non-2xx status code. The client wraps RPC calls with `parseResponse` from `hono/client`, which throws `DetailedError` only on non-2xx — a 200 response with an error-shaped body silently flows through `onSuccess` and breaks the entire error-logging contract.
+Every error path MUST return a non-2xx status code. The client wraps RPC calls with `parseResponse` from `hono/client`, which throws `DetailedError` only on non-2xx — a 200 response with an error-shaped body silently flows through `onSuccess` and breaks the entire flow.
 
 ```ts
 // Right
@@ -86,7 +86,13 @@ return c.json({error: 'No file provided'}, 400)
 return c.json({error: 'No file provided'})
 ```
 
-Do not pass a 3rd-argument hook to `arktypeValidator`. The default behavior already returns a 400 with the full validation breakdown, which is richer than a hand-written message and gets logged via `logClientError` on failure.
+Do not pass a 3rd-argument hook to `arktypeValidator`. The default behavior already returns a 400 with the full validation breakdown, which is richer than a hand-written message.
+
+### Capturing errors
+
+- **4xx responses are not errors.** They mean the request was bad (validation, wrong password, file too large). The system worked. Don't call `captureError`.
+- **5xx and unhandled throws** are captured automatically by Hono's `.onError` (`hono:topLevel:exception`). Prefer `throw new HTTPException(500, ...)` over manually returning 500 so onError fires.
+- **Third-party SDK failures** (e.g. Resend, Stripe) get explicit captures at the boundary with `<service>:<operation>:rejection` (SDK returned a failure result) or `<service>:<operation>:exception` (SDK call threw). Use `captureError` from `@/server/utils/captureError`.
 
 ## Fire-and-Forget
 

--- a/src/projects/fullstack/.claude-keep/skills/add-error-context/SKILL.md
+++ b/src/projects/fullstack/.claude-keep/skills/add-error-context/SKILL.md
@@ -10,43 +10,58 @@ Add a new entry to the `ErrorContext` union type in `src/shared/types.d.ts`.
 
 ## Naming Convention
 
-Format: `<service>:<operation><Suffix>`
+Format: `<service>:<operation>:<suffix>` — three colon-separated segments. Suffix is lowercase, one of:
 
-### 1. Client API calls — Rejection + Exception pair
+- `:exception` — code threw or a third-party call raised inside a try/catch
+- `:rejection` — a third party returned a non-success response we treat as an error (e.g. Resend API error, Better Auth handler returning 5xx)
+
+## What gets captured (and what doesn't)
+
+The `errors` table stores genuine system errors. Things that are **expected UX** are not errors and must not be captured:
+
+- Wrong password, validation 400s, expired tokens, "file too large" — user input, the system worked.
+- 4xx responses generally — the server is correctly telling the client the request was bad.
+
+Capture only when something genuinely went wrong: code threw, the network failed, a third party returned 5xx, etc.
+
+## Where to capture
+
+| Site                              | Suffix     | Example                                          |
+|-----------------------------------|------------|--------------------------------------------------|
+| Server `try/catch` of own code    | `:exception` | `hono:topLevel:exception`                      |
+| Server wrapper of 3rd-party SDK   | `:exception` | `resend:sendResetPasswordEmail:exception`      |
+| 3rd-party returns failure result  | `:rejection` | `resend:sendResetPasswordEmail:rejection`      |
+| Black-box handler returns 5xx     | `:rejection` | `betterAuth:topLevel:rejection`                |
+| Standalone server invariant      | `:exception` | `dbCleanup:purgeStaleRecords:exception`        |
+| Client `catch (error)` of fetch   | `:exception` | `client:signIn:exception`                      |
+| React error boundary              | `:exception` | `client:topLevel:exception`                    |
+
+**There are no `client:*:rejection` contexts.** Rejection-class outcomes — the server told the client a request failed — are server-owned. The server captures them at the source (or doesn't capture, if the failure is expected UX). The client only captures what only the client can see: catch-block exceptions and React render failures.
+
+## Capturing the error
+
+Server: `captureError({context, error, metadata?, userId?})` from `@/server/utils/captureError`.
 
 ```ts
-| 'client:<operation>Rejection'
-| 'client:<operation>Exception'
+import {captureError} from '@/server/utils/captureError'
+
+captureError({context: 'myService:myOp:exception', error})
 ```
 
-Hono RPC calls are wrapped with `parseResponse` from `hono/client` inside `useMutation` / `useQuery`. `parseResponse` returns the typed body on 2xx and throws `DetailedError` on non-2xx, so all failures land in `onError`. In the `onError` handler, branch on `error instanceof DetailedError` to pick the context tag:
-
-- **Rejection** — `error instanceof DetailedError` is `true`. Server replied with a non-2xx status; `parseResponse` threw `DetailedError`. Tag: `client:<operation>Rejection`.
-- **Exception** — `error instanceof DetailedError` is `false`. Anything else thrown inside `mutationFn` / `queryFn` (network/CORS failure, JSON parse error, code error). Tag: `client:<operation>Exception`.
-
-### 2. Server-side async calls to external services — Rejection + Exception pair
+Client: `useCaptureError()` returns `({error, context, metadata?}) => void`.
 
 ```ts
-| '<service>:<operation>Rejection'
-| '<service>:<operation>Exception'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
+
+const captureError = useCaptureError()
+captureError({error, context: 'client:myFeature:exception'})
 ```
-
-- Same Rejection/Exception distinction as client calls
-- `<service>` is the external service name (e.g. `resend`, `stripe`, etc.)
-
-### 3. Standalone error scenarios — Exception only
-
-```ts
-| '<area>:<name>Exception'
-```
-
-- For catch-all handlers or one-off error scenarios with no corresponding rejection
-- `<area>` is the service or subsystem (e.g. `hono`, `betterAuth`, etc.)
 
 ## Rules
 
-- All names are camelCase after the colon
-- Place new entries in the correct section (Server or Client) with a comment if starting a new group
-- Check existing entries in the union to match naming style
+- camelCase the `<service>` and `<operation>` segments
+- `<suffix>` is lowercase
+- Place the new entry in the correct section (Server or Client) of the union
+- Match existing entries' style; check the union before adding
 
 See [CONVENTIONS](../CONVENTIONS.md) for finalize steps and rules.

--- a/src/projects/fullstack/.claude-keep/skills/add-feature/SKILL.md
+++ b/src/projects/fullstack/.claude-keep/skills/add-feature/SKILL.md
@@ -35,32 +35,33 @@ Each step validates before next:
 - If schema changed: remind to stop dev server, run `bun run db:init`
 - Verify Hono RPC types flow (server type export → client atom consumption)
 
-## Error Logging
+## Error Capture
 
-Client:
+Server-side (genuine system errors only — 4xx user-input outcomes are not errors):
+
 ```ts
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {captureError} from '@/server/utils/captureError'
 
-const logClientError = useLogClientError()
-logClientError({error, context: 'client:featureNameException'})
+// Inside a try/catch around your own code or a 3rd-party SDK
+captureError({context: 'myService:myOp:exception', error})
 ```
 
-Server:
-```ts
-import {bestEffort, errorToObject} from '@qodestack/utils'
+Client-side (catch blocks for genuine code/network failures only):
 
-bestEffort(() => {
-  db.insert(errorsTable)
-    .values({error: errorToObject(error), context: 'server:featureNameException'})
-    .run()
-})
+```ts
+import {useCaptureError} from '@/client/hooks/useCaptureError'
+
+const captureError = useCaptureError()
+
+// Inside a catch — never inside an `if (error)` branch from a structured response
+captureError({error, context: 'client:myFeature:exception'})
 ```
 
 ## RPC Wiring
 
-Always wrap the call with `parseResponse` from `hono/client` inside `useMutation` or `useQuery`. `parseResponse` returns the typed body on 2xx and throws `DetailedError` on non-2xx.
+Wrap the call with `parseResponse` from `hono/client` inside `useMutation` or `useQuery`. `parseResponse` returns the typed body on 2xx and throws `DetailedError` on non-2xx.
 
-In `onError`, branch on `error instanceof DetailedError` to split the log context: Rejection = server replied non-2xx, Exception = request never completed (network, CORS, code throw).
+In `onError`, `error instanceof DetailedError` means the server told us the request failed — that's already known to the server, so don't capture it. Only capture true client-side exceptions (e.g. network failures, JS errors):
 
 ```ts
 import {useMutation} from '@tanstack/react-query'
@@ -69,6 +70,7 @@ import {useAtomValue} from 'jotai'
 import {apiAuthClientAtom} from '@/client/state/globalState'
 
 const apiAuthClient = useAtomValue(apiAuthClientAtom)
+const captureError = useCaptureError()
 
 const myMutation = useMutation({
   mutationFn: async (input: MyInput) => {
@@ -76,15 +78,12 @@ const myMutation = useMutation({
   },
   onSuccess: data => { /* typed success body */ },
   onError: error => {
-    const isRejection = error instanceof DetailedError
-
-    toast.error('Friendly message')
-    logClientError({
-      error,
-      context: isRejection
-        ? 'client:myFeatureRejection'
-        : 'client:myFeatureException',
-    })
+    toast.error(error.message)
+    // DetailedError = server-known rejection. Server captures (or chooses not to)
+    // at its source. Only client-side exceptions need capture here.
+    if (!(error instanceof DetailedError)) {
+      captureError({error, context: 'client:myFeature:exception'})
+    }
   },
 })
 ```

--- a/src/projects/fullstack/src/client/hooks/useCaptureError.ts
+++ b/src/projects/fullstack/src/client/hooks/useCaptureError.ts
@@ -8,13 +8,14 @@ import {useAtomValue} from 'jotai'
 import {useCallback} from 'react'
 
 /**
- * Logs client-side errors to the server for centralized error tracking.
+ * Persists a client-only error to the server's `errors` table via `/api/capture`.
  *
- * @param error - The error object or unknown value to be logged
- * @param context - Used for observability and debugging in the logs
- * @param metadata - Optional adhoc data with no specific shape, used to provide additional context
+ * Use only for genuine client-side problems: catch-block exceptions (network
+ * failures, unhandled JS errors), React error-boundary catches. Do NOT call
+ * for normal API rejections (wrong password, validation 400s) — those are
+ * expected UX, and any 5xx the server produced is captured server-side.
  */
-function logClientError({
+function captureError({
   error,
   context,
   metadata,
@@ -27,7 +28,7 @@ function logClientError({
 }): void {
   bestEffort(
     () => {
-      apiClient['client-error'].$post({
+      apiClient.capture.$post({
         json: {error: errorToObject(error), context, metadata},
       })
     },
@@ -35,7 +36,7 @@ function logClientError({
   )
 }
 
-export function useLogClientError() {
+export function useCaptureError() {
   const apiClient = useAtomValue(apiClientAtom)
 
   return useCallback(
@@ -48,7 +49,7 @@ export function useLogClientError() {
       context: ErrorContext
       metadata?: Record<string, unknown>
     }) => {
-      logClientError({error, context, metadata, apiClient})
+      captureError({error, context, metadata, apiClient})
     },
     [apiClient]
   )

--- a/src/projects/fullstack/src/client/hooks/useSignOut.ts
+++ b/src/projects/fullstack/src/client/hooks/useSignOut.ts
@@ -1,4 +1,4 @@
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {authClientAtom, isSignedInAtom} from '@/client/state/globalState'
 
 import {useRouteContext} from '@tanstack/react-router'
@@ -10,30 +10,25 @@ export function useSignOut() {
   const setIsSignedIn = useSetAtom(isSignedInAtom)
   const {resetApp} = useRouteContext({from: '__root__'})
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
   const signOut = useCallback(async () => {
     setIsSigningOut(true)
 
     try {
-      const {data, error} = await authClient.signOut()
+      const {data} = await authClient.signOut()
       const isSignedOut = !!data?.success
 
-      if (isSignedOut) {
-        resetApp()
-      } else if (error) {
-        logClientError({error, context: 'client:signOutRejection'})
-      }
-
+      if (isSignedOut) resetApp()
       setIsSignedIn(!isSignedOut)
 
       return isSignedOut
     } catch (error) {
-      logClientError({error, context: 'client:signOutException'})
+      captureError({error, context: 'client:signOut:exception'})
       return false
     } finally {
       setIsSigningOut(false)
     }
-  }, [setIsSignedIn, resetApp, logClientError, authClient])
+  }, [setIsSignedIn, resetApp, captureError, authClient])
 
   return {signOut, isSigningOut}
 }

--- a/src/projects/fullstack/src/client/router.tsx
+++ b/src/projects/fullstack/src/client/router.tsx
@@ -1,7 +1,7 @@
 import {AudioLoader} from '@/client/components/custom/AudioLoader'
 import {ErrorState} from '@/client/components/custom/ErrorState'
 import {Button} from '@/client/components/ui/button'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 
 import {createRouter, useRouter} from '@tanstack/react-router'
 import {useEffect} from 'react'
@@ -36,7 +36,7 @@ export function createTanstackRouter() {
 
     // Catches errors in the component's loader and render cycle.
     defaultErrorComponent: ({error, info, reset: resetErrorBoundary}) => {
-      const logClientError = useLogClientError()
+      const captureError = useCaptureError()
       const isValidationError = 'code' in error && error.code === 'validation'
       const title = isValidationError
         ? 'Data failed to load'
@@ -51,12 +51,12 @@ export function createTanstackRouter() {
       }
 
       useEffect(() => {
-        logClientError({
+        captureError({
           error,
-          context: 'client:topLevelException',
+          context: 'client:topLevel:exception',
           metadata: info,
         })
-      }, [logClientError, info, error])
+      }, [captureError, info, error])
 
       return (
         <ErrorState

--- a/src/projects/fullstack/src/client/routes/_authenticated/account/-AccountAvatar.tsx
+++ b/src/projects/fullstack/src/client/routes/_authenticated/account/-AccountAvatar.tsx
@@ -9,7 +9,7 @@ import {
 import {Input} from '@/client/components/ui/input'
 import {Label} from '@/client/components/ui/label'
 import {Separator} from '@/client/components/ui/separator'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {apiAuthClientAtom} from '@/client/state/globalState'
 import {authRoutePath, maxAvatarUploadSize} from '@/shared/constants'
 
@@ -40,7 +40,7 @@ export function AccountAvatar() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const avatarInputId = useId()
   const apiAuthClient = useAtomValue(apiAuthClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
 
   const clearPreview = () => {
     if (blobPreviewUrl) URL.revokeObjectURL(blobPreviewUrl)
@@ -59,15 +59,12 @@ export function AccountAvatar() {
       clearPreview()
     },
     onError: error => {
-      const isRejection = error instanceof DetailedError
-
       toast.error(error.message)
-      logClientError({
-        error,
-        context: isRejection
-          ? 'client:avatarUploadRejection'
-          : 'client:avatarUploadException',
-      })
+      // Server-known failures (DetailedError = non-2xx response) are captured
+      // server-side. Only true client exceptions need to round-trip.
+      if (!(error instanceof DetailedError)) {
+        captureError({error, context: 'client:avatarUpload:exception'})
+      }
       setShowImage(false)
     },
   })
@@ -81,15 +78,10 @@ export function AccountAvatar() {
       setShowImage(false)
     },
     onError: error => {
-      const isRejection = error instanceof DetailedError
-
       toast.error('Failed to remove avatar')
-      logClientError({
-        error,
-        context: isRejection
-          ? 'client:avatarDeleteRejection'
-          : 'client:avatarDeleteException',
-      })
+      if (!(error instanceof DetailedError)) {
+        captureError({error, context: 'client:avatarDelete:exception'})
+      }
       setShowImage(true)
     },
   })

--- a/src/projects/fullstack/src/client/routes/_authenticated/account/-ChangeEmail.tsx
+++ b/src/projects/fullstack/src/client/routes/_authenticated/account/-ChangeEmail.tsx
@@ -3,7 +3,7 @@ import type {FileRouteTypes} from '@/client/routeTree.gen'
 import {Button} from '@/client/components/ui/button'
 import {Input} from '@/client/components/ui/input'
 import {Label} from '@/client/components/ui/label'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 
@@ -13,7 +13,7 @@ import {toast} from 'sonner'
 
 export function ChangeEmail() {
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
 
   const changeEmailForm = useForm({
     defaultValues: {
@@ -38,10 +38,6 @@ export function ChangeEmail() {
 
         if (error) {
           toast.error(error.message || 'Failed to change email')
-          logClientError({
-            error,
-            context: 'client:changeEmailRejection',
-          })
           return
         }
 
@@ -51,10 +47,7 @@ export function ChangeEmail() {
         )
       } catch (error) {
         toast.error('An unexpected error occurred while updating your email')
-        logClientError({
-          error,
-          context: 'client:changeEmailException',
-        })
+        captureError({error, context: 'client:changeEmail:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/client/routes/_authenticated/account/-ChangePassword.tsx
+++ b/src/projects/fullstack/src/client/routes/_authenticated/account/-ChangePassword.tsx
@@ -1,7 +1,7 @@
 import {PasswordInput} from '@/client/components/custom/PasswordInput'
 import {PasswordManagerHint} from '@/client/components/custom/PasswordManagerHint'
 import {Button} from '@/client/components/ui/button'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 import {minPasswordLength} from '@/shared/constants'
@@ -12,7 +12,7 @@ import {toast} from 'sonner'
 
 export function ChangePassword() {
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
 
   const changePasswordForm = useForm({
     defaultValues: {
@@ -39,10 +39,6 @@ export function ChangePassword() {
 
         if (error) {
           toast.error(error.message || 'Failed to change password')
-          logClientError({
-            error,
-            context: 'client:changePasswordRejection',
-          })
           return
         }
 
@@ -50,10 +46,7 @@ export function ChangePassword() {
         changePasswordForm.reset()
       } catch (error) {
         toast.error('An unexpected error occurred while updating your password')
-        logClientError({
-          error,
-          context: 'client:changePasswordException',
-        })
+        captureError({error, context: 'client:changePassword:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/client/routes/_authenticated/account/-DeleteAccount.tsx
+++ b/src/projects/fullstack/src/client/routes/_authenticated/account/-DeleteAccount.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from '@/client/components/ui/dialog'
 import {useBoolean} from '@/client/hooks/useBoolean'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 
@@ -22,7 +22,7 @@ import {toast} from 'sonner'
 
 export function DeleteAccount() {
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
   const deleteDialog = useBoolean()
 
   const form = useForm({
@@ -38,10 +38,6 @@ export function DeleteAccount() {
 
         if (error) {
           toast.error(error.message || 'Failed to request account deletion')
-          logClientError({
-            error,
-            context: 'client:deleteAccountRejection',
-          })
           return
         }
 
@@ -50,10 +46,7 @@ export function DeleteAccount() {
         toast.success('Check your email to confirm account deletion')
       } catch (error) {
         toast.error('An unexpected error occurred while deleting your account')
-        logClientError({
-          error,
-          context: 'client:deleteAccountException',
-        })
+        captureError({error, context: 'client:deleteAccount:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/client/routes/_authenticated/account/-Passkeys.tsx
+++ b/src/projects/fullstack/src/client/routes/_authenticated/account/-Passkeys.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
 } from '@/client/components/ui/dialog'
 import {Input} from '@/client/components/ui/input'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {authClientAtom} from '@/client/state/globalState'
 
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
@@ -24,7 +24,7 @@ type Passkey = AuthSchemaInsert['passkeys']
 
 export function Passkeys() {
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
   const queryClient = useQueryClient()
   const [addName, setAddName] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<Passkey | null>(null)
@@ -45,15 +45,16 @@ export function Passkeys() {
         const {data, error} = await authClient.passkey.listUserPasskeys()
 
         if (error) {
+          // Better Auth returned a structured error — not a client exception.
+          // Don't capture; rejection-class outcomes are server-owned.
           isRejection = true
-          logClientError({error, context: 'client:passkeyListRejection'})
           throw error
         }
 
         return data ?? []
       } catch (error) {
         if (!isRejection) {
-          logClientError({error, context: 'client:passkeyListException'})
+          captureError({error, context: 'client:passkeyList:exception'})
         }
 
         /**
@@ -77,10 +78,6 @@ export function Passkeys() {
     onSuccess: result => {
       if (result?.error) {
         toast.error(result.error.message || 'Failed to add passkey')
-        logClientError({
-          error: result.error,
-          context: 'client:passkeyAddRejection',
-        })
         return
       }
 
@@ -95,7 +92,7 @@ export function Passkeys() {
       }
 
       toast.error('Failed to add passkey')
-      logClientError({error, context: 'client:passkeyAddException'})
+      captureError({error, context: 'client:passkeyAdd:exception'})
     },
   })
 
@@ -104,10 +101,6 @@ export function Passkeys() {
     onSuccess: result => {
       if (result?.error) {
         toast.error(result.error.message || 'Failed to delete passkey')
-        logClientError({
-          error: result.error,
-          context: 'client:passkeyDeleteRejection',
-        })
         return
       }
 
@@ -117,7 +110,7 @@ export function Passkeys() {
     },
     onError: error => {
       toast.error('Failed to delete passkey')
-      logClientError({error, context: 'client:passkeyDeleteException'})
+      captureError({error, context: 'client:passkeyDelete:exception'})
     },
   })
 

--- a/src/projects/fullstack/src/client/routes/reset-password.lazy.tsx
+++ b/src/projects/fullstack/src/client/routes/reset-password.lazy.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/client/components/ui/card'
 import {MagicCard} from '@/client/components/ui/magic-card'
 import {useBoolean} from '@/client/hooks/useBoolean'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 import {minPasswordLength} from '@/shared/constants'
@@ -57,7 +57,7 @@ function NewPasswordForm({
 }) {
   const router = useRouter()
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
 
   const form = useForm({
     defaultValues: {
@@ -74,10 +74,6 @@ function NewPasswordForm({
 
         if (error) {
           toast.error(error.message || 'Failed to reset password')
-          logClientError({
-            error,
-            context: 'client:resetPasswordRejection',
-          })
           showInvalidTokenView()
           return
         }
@@ -86,10 +82,7 @@ function NewPasswordForm({
         await router.navigate({to: '/signin'})
       } catch (error) {
         toast.error('An unexpected error occurred')
-        logClientError({
-          error,
-          context: 'client:resetPasswordException',
-        })
+        captureError({error, context: 'client:resetPassword:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/client/routes/signin/-ResetPasswordDialog.tsx
+++ b/src/projects/fullstack/src/client/routes/signin/-ResetPasswordDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from '@/client/components/ui/dialog'
 import {Input} from '@/client/components/ui/input'
 import {useBoolean} from '@/client/hooks/useBoolean'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 
@@ -25,7 +25,7 @@ export function ResetPasswordDialog({
   dialogInitialOpen: boolean
 }) {
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
   const {value: isOpen, setValue: setIsOpen} = useBoolean(dialogInitialOpen)
 
   const form = useForm({
@@ -43,10 +43,6 @@ export function ResetPasswordDialog({
 
         if (error) {
           toast.error('Failed to send reset email')
-          logClientError({
-            error,
-            context: 'client:requestPasswordResetRejection',
-          })
         } else {
           toast.success('Check your email for a link to reset your password.')
         }
@@ -54,9 +50,9 @@ export function ResetPasswordDialog({
         setIsOpen(false)
       } catch (error) {
         toast.error('An unexpected error occurred')
-        logClientError({
+        captureError({
           error,
-          context: 'client:requestPasswordResetException',
+          context: 'client:requestPasswordReset:exception',
         })
       }
     },

--- a/src/projects/fullstack/src/client/routes/signin/route.lazy.tsx
+++ b/src/projects/fullstack/src/client/routes/signin/route.lazy.tsx
@@ -10,7 +10,7 @@ import {Input} from '@/client/components/ui/input'
 import {MagicCard} from '@/client/components/ui/magic-card'
 import {Separator} from '@/client/components/ui/separator'
 import {defaultAuthedPath} from '@/client/constants'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {isValidRoute} from '@/client/lib/isValidRoute'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {ResetPasswordDialog} from '@/client/routes/signin/-ResetPasswordDialog'
@@ -31,7 +31,7 @@ export const Route = createLazyFileRoute('/signin')({
 function SignInPage() {
   const router = useRouter()
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
   const setIsSignedIn = useSetAtom(isSignedInAtom)
   const {redirect, dialogInitialOpen} = Route.useSearch()
   const redirectPath = isValidRoute(router, redirect)
@@ -47,10 +47,6 @@ function SignInPage() {
 
       if (result?.error) {
         toast.error(result.error.message || 'Failed to sign in with passkey')
-        logClientError({
-          error: result.error,
-          context: 'client:passkeySignInRejection',
-        })
         return
       }
 
@@ -62,10 +58,7 @@ function SignInPage() {
       if (isWebAuthnCancellation) return
 
       toast.error('Failed to sign in with passkey')
-      logClientError({
-        error,
-        context: 'client:passkeySignInException',
-      })
+      captureError({error, context: 'client:passkeySignIn:exception'})
     } finally {
       setIsPasskeyLoading(false)
     }
@@ -86,10 +79,6 @@ function SignInPage() {
 
         if (result.error) {
           toast.error(result.error.message || 'Failed to sign in')
-          logClientError({
-            error: result.error,
-            context: 'client:signInRejection',
-          })
           return
         }
 
@@ -97,10 +86,7 @@ function SignInPage() {
         await router.navigate({to: redirectPath})
       } catch (error) {
         toast.error('An unexpected error occurred')
-        logClientError({
-          error,
-          context: 'client:signInException',
-        })
+        captureError({error, context: 'client:signIn:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/client/routes/signup.lazy.tsx
+++ b/src/projects/fullstack/src/client/routes/signup.lazy.tsx
@@ -9,7 +9,7 @@ import {
 import {Input} from '@/client/components/ui/input'
 import {MagicCard} from '@/client/components/ui/magic-card'
 import {defaultAuthedPath} from '@/client/constants'
-import {useLogClientError} from '@/client/hooks/useLogClientError'
+import {useCaptureError} from '@/client/hooks/useCaptureError'
 import {handleFormSubmitInvalid} from '@/client/lib/utils'
 import {authClientAtom} from '@/client/state/globalState'
 import {
@@ -31,7 +31,7 @@ export const Route = createLazyFileRoute('/signup')({
 function SignUpPage() {
   const router = useRouter()
   const authClient = useAtomValue(authClientAtom)
-  const logClientError = useLogClientError()
+  const captureError = useCaptureError()
 
   const form = useForm({
     defaultValues: {
@@ -54,7 +54,6 @@ function SignUpPage() {
 
         if (error) {
           toast.error(error.message || 'Failed to sign up')
-          logClientError({error, context: 'client:signUpRejection'})
           return
         }
 
@@ -62,7 +61,7 @@ function SignUpPage() {
         await router.navigate({to: '/signin'})
       } catch (error) {
         toast.error('An unexpected error occurred')
-        logClientError({error, context: 'client:signUpException'})
+        captureError({error, context: 'client:signUp:exception'})
       }
     },
   })

--- a/src/projects/fullstack/src/server/db/auth/auth.ts
+++ b/src/projects/fullstack/src/server/db/auth/auth.ts
@@ -143,8 +143,8 @@ export const authOptions = {
           user,
           subject: 'Verify your email address',
           react: SignUpVerificationEmail({verificationUrl: url}),
-          rejectionContext: 'resend:sendSignUpVerificationEmailRejection',
-          exceptionContext: 'resend:sendSignUpVerificationEmailException',
+          rejectionContext: 'resend:sendSignUpVerificationEmail:rejection',
+          exceptionContext: 'resend:sendSignUpVerificationEmail:exception',
         })
       }
 
@@ -167,8 +167,8 @@ export const authOptions = {
             verificationUrl: url,
             newEmail: user.email,
           }),
-          rejectionContext: 'resend:sendChangeEmailRejection',
-          exceptionContext: 'resend:sendChangeEmailException',
+          rejectionContext: 'resend:sendChangeEmail:rejection',
+          exceptionContext: 'resend:sendChangeEmail:exception',
         })
       }
     },
@@ -195,8 +195,8 @@ export const authOptions = {
         user,
         subject: 'Reset your password',
         react: ResetPasswordEmail({resetUrl: url}),
-        rejectionContext: 'resend:sendResetPasswordEmailRejection',
-        exceptionContext: 'resend:sendResetPasswordEmailException',
+        rejectionContext: 'resend:sendResetPasswordEmail:rejection',
+        exceptionContext: 'resend:sendResetPasswordEmail:exception',
       })
     },
 
@@ -258,8 +258,8 @@ export const authOptions = {
       //     user,
       //     subject: 'Confirm your updated email',
       //     react: ChangeEmailVerificationEmail({verificationUrl: url, newEmail}),
-      //     rejectionContext: 'resend:sendChangeEmailRejection',
-      //     exceptionContext: 'resend:sendChangeEmailException',
+      //     rejectionContext: 'resend:sendChangeEmail:rejection',
+      //     exceptionContext: 'resend:sendChangeEmail:exception',
       //   })
       // },
     },
@@ -274,9 +274,9 @@ export const authOptions = {
           subject: 'Confirm account deletion',
           react: DeleteAccountVerificationEmail({verificationUrl: url}),
           rejectionContext:
-            'resend:sendDeleteAccountVerificationEmailRejection',
+            'resend:sendDeleteAccountVerificationEmail:rejection',
           exceptionContext:
-            'resend:sendDeleteAccountVerificationEmailException',
+            'resend:sendDeleteAccountVerificationEmail:exception',
         })
       },
     },

--- a/src/projects/fullstack/src/server/dbCleanup.ts
+++ b/src/projects/fullstack/src/server/dbCleanup.ts
@@ -15,10 +15,11 @@ import {
   systemAuditLogsTable,
 } from '@/server/db/schema/appSchema'
 import {ratelimits, users, verifications} from '@/server/db/schema/authSchema'
+import {captureError} from '@/server/utils/captureError'
 import {log} from '@/server/utils/logger'
 import {emailVerificationExpiryInMs} from '@/shared/constants'
 
-import {bestEffort, errorToObject, getUnitInMs} from '@qodestack/utils'
+import {bestEffort, getUnitInMs} from '@qodestack/utils'
 import {and, eq, lt} from 'drizzle-orm'
 
 const oneHourInMs = getUnitInMs(1, 'h')
@@ -71,16 +72,10 @@ export function purgeStaleRecords({
   if (!(isAdmin || opts.system)) {
     const errorMsg = 'Refusing to purge stale records - unknown actor'
     log.error(errorMsg)
-
-    bestEffort(() => {
-      db.insert(errorsTable)
-        .values({
-          error: errorToObject(new Error(errorMsg)),
-          context: 'dbCleanup:purgeStaleRecordsException',
-        })
-        .run()
+    captureError({
+      context: 'dbCleanup:purgeStaleRecords:exception',
+      error: new Error(errorMsg),
     })
-
     return {...nothingPurged, message: errorMsg}
   }
 
@@ -96,16 +91,10 @@ export function purgeStaleRecords({
     if (!adminUser) {
       const errorMsg = `Refusing to purge stale records - admin user not found for id '${adminId}'`
       log.error(errorMsg)
-
-      bestEffort(() => {
-        db.insert(errorsTable)
-          .values({
-            error: errorToObject(new Error(errorMsg)),
-            context: 'dbCleanup:purgeStaleRecordsException',
-          })
-          .run()
+      captureError({
+        context: 'dbCleanup:purgeStaleRecords:exception',
+        error: new Error(errorMsg),
       })
-
       return {...nothingPurged, message: errorMsg}
     }
   }

--- a/src/projects/fullstack/src/server/email/sendEmail.ts
+++ b/src/projects/fullstack/src/server/email/sendEmail.ts
@@ -2,11 +2,9 @@ import type {JSX} from 'react'
 import type {ErrorContext} from '@/shared/types'
 
 import {isProd} from '@/server/constants'
-import {getDatabase} from '@/server/db/getDatabase'
-import {errorsTable} from '@/server/db/schema/appSchema'
+import {captureError} from '@/server/utils/captureError'
 import {getEnvVar} from '@/server/utils/getEnvVar'
 
-import {bestEffort, errorToObject} from '@qodestack/utils'
 import {Resend} from 'resend'
 
 export async function sendEmail({
@@ -31,31 +29,14 @@ export async function sendEmail({
     .send({from, to, subject, react})
     .then(res => {
       if (res.error !== null) {
-        const db = getDatabase()
-        const error = errorToObject(res.error)
-        const metadata = res.headers === null ? null : {headers: res.headers}
-
-        bestEffort(
-          () => {
-            db.insert(errorsTable)
-              .values({context: rejectionContext, error, metadata})
-              .run()
-          },
-          {log: true}
-        )
+        captureError({
+          context: rejectionContext,
+          error: res.error,
+          metadata: res.headers === null ? undefined : {headers: res.headers},
+        })
       }
     })
-    .catch(e => {
-      const db = getDatabase()
-      const error = errorToObject(e)
-
-      bestEffort(
-        () => {
-          db.insert(errorsTable)
-            .values({context: exceptionContext, error})
-            .run()
-        },
-        {log: true}
-      )
+    .catch(error => {
+      captureError({context: exceptionContext, error})
     })
 }

--- a/src/projects/fullstack/src/server/hono/honoServer.ts
+++ b/src/projects/fullstack/src/server/hono/honoServer.ts
@@ -9,10 +9,11 @@ import indexHtml from '@/server/index.html'
 import {corsMiddleware} from '@/server/middleware/corsMiddleware'
 import {getRateLimitMiddleware} from '@/server/middleware/rateLimitMiddleware'
 import {secureHeadersMiddleware} from '@/server/middleware/secureHeadersMiddleware'
+import {captureError} from '@/server/utils/captureError'
 import {authRoutePath, betterAuthBasePath} from '@/shared/constants'
 
 import {arktypeValidator} from '@hono/arktype-validator'
-import {bestEffort, errorToObject, getUnitInMs} from '@qodestack/utils'
+import {getUnitInMs} from '@qodestack/utils'
 import {createInsertSchema} from 'drizzle-arktype'
 import {sql} from 'drizzle-orm'
 import {Hono} from 'hono'
@@ -37,19 +38,24 @@ export const honoServer = new Hono()
   .on(['POST', 'GET'], `${betterAuthBasePath}/*`, async c => {
     try {
       const res = await auth.handler(c.req.raw)
+
+      /**
+       * Better Auth normally throws on internal failure (caught below). It can
+       * also return 5xx without throwing — capture those rejections so server
+       * problems surface in the errors table without a client round-trip.
+       * 4xx (wrong password, validation, etc.) is expected UX, not an error.
+       */
+      if (res.status >= 500) {
+        const body = await res.clone().text()
+        captureError({
+          context: 'betterAuth:topLevel:rejection',
+          error: {status: res.status, body, url: c.req.url},
+        })
+      }
+
       return res
     } catch (error) {
-      const db = getDatabase()
-
-      bestEffort(() => {
-        db.insert(errorsTable)
-          .values({
-            error: errorToObject(error),
-            context: 'betterAuth:topLevelException',
-          })
-          .run()
-      })
-
+      captureError({context: 'betterAuth:topLevel:exception', error})
       throw error
     }
   })
@@ -109,8 +115,8 @@ export const honoServer = new Hono()
   .route(authRoutePath, authRoutes)
 
   .post(
-    '/api/client-error',
-    // Max 5 errors per second.
+    '/api/capture',
+    // Max 1 capture per second per IP.
     getRateLimitMiddleware({windowMs: getUnitInMs(1, 's'), limit: 1}),
     arktypeValidator(
       'json',
@@ -122,7 +128,6 @@ export const honoServer = new Hono()
       )
     ),
     async c => {
-      const db = getDatabase()
       const {error, context, metadata} = c.req.valid('json')
 
       /**
@@ -130,11 +135,8 @@ export const honoServer = new Hono()
        * directly to see if we have an authenticated user to grab their id.
        */
       const session = await auth.api.getSession({headers: c.req.raw.headers})
-      const userId = session?.user.id
 
-      bestEffort(() => {
-        db.insert(errorsTable).values({error, context, userId, metadata}).run()
-      })
+      captureError({context, error, metadata, userId: session?.user.id})
 
       return c.body(null)
     }
@@ -165,16 +167,7 @@ export const honoServer = new Hono()
     return c.html(await res.text())
   })
   .onError((error, c) => {
-    const db = getDatabase()
-
-    bestEffort(() => {
-      db.insert(errorsTable)
-        .values({
-          error: errorToObject(error),
-          context: 'hono:topLevelException',
-        })
-        .run()
-    })
+    captureError({context: 'hono:topLevel:exception', error})
 
     /**
      * Bun and Hono servers will both return 500 in their error handlers. They

--- a/src/projects/fullstack/src/server/middleware/rateLimitMiddleware.ts
+++ b/src/projects/fullstack/src/server/middleware/rateLimitMiddleware.ts
@@ -3,10 +3,9 @@ import type {MiddlewareHandler} from 'hono'
 import process from 'node:process'
 
 import {isProd} from '@/server/constants'
-import {getDatabase} from '@/server/db/getDatabase'
-import {errorsTable} from '@/server/db/schema/appSchema'
+import {captureError} from '@/server/utils/captureError'
 
-import {bestEffort, getUnitInMs} from '@qodestack/utils'
+import {getUnitInMs} from '@qodestack/utils'
 import {getConnInfo} from 'hono/bun'
 import {HTTPException} from 'hono/http-exception'
 import {rateLimiter} from 'hono-rate-limiter'
@@ -37,20 +36,14 @@ export function getRateLimitMiddleware({
             info.remote.address
 
           if (!ipAddress) {
-            const db = getDatabase()
-
-            bestEffort(() => {
-              db.insert(errorsTable)
-                .values({
-                  context: 'hono:rateLimitException',
-                  error: {
-                    message: 'unknownIpAddress',
-                    connectionInfo: info,
-                    url: c.req.url,
-                    httpMethod: c.req.method,
-                  },
-                })
-                .run()
+            captureError({
+              context: 'hono:rateLimit:exception',
+              error: {
+                message: 'unknownIpAddress',
+                connectionInfo: info,
+                url: c.req.url,
+                httpMethod: c.req.method,
+              },
             })
 
             throw new HTTPException(403, {message: 'Forbidden'})

--- a/src/projects/fullstack/src/server/utils/captureError.ts
+++ b/src/projects/fullstack/src/server/utils/captureError.ts
@@ -1,0 +1,48 @@
+import type {ErrorContext} from '@/shared/types'
+
+import {getDatabase} from '@/server/db/getDatabase'
+import {errorsTable} from '@/server/db/schema/appSchema'
+
+import {bestEffort, errorToObject} from '@qodestack/utils'
+
+/**
+ * Persists an error to the `errors` table. Best-effort: never throws, never
+ * blocks. The deep module — every server-side capture site goes through this
+ * single function rather than re-implementing the `getDatabase` + `errorToObject`
+ * + `bestEffort` + `db.insert(...)` chain.
+ *
+ * `error` accepts anything (Error, string, plain object, response body) and is
+ * normalized via `errorToObject`. Pass already-shaped objects (e.g. a fabricated
+ * `{message, ...}`) through as-is — they're left intact.
+ */
+export function captureError({
+  context,
+  error,
+  metadata,
+  userId,
+}: {
+  context: ErrorContext
+  error: unknown
+  metadata?: Record<string, unknown> | null
+  userId?: string | null
+}): void {
+  const db = getDatabase()
+  const normalizedError =
+    error && typeof error === 'object' && !(error instanceof Error)
+      ? (error as Record<string, unknown>)
+      : errorToObject(error)
+
+  bestEffort(
+    () => {
+      db.insert(errorsTable)
+        .values({
+          context,
+          error: normalizedError,
+          metadata: metadata ?? undefined,
+          userId: userId ?? undefined,
+        })
+        .run()
+    },
+    {log: true}
+  )
+}

--- a/src/projects/fullstack/src/shared/types.d.ts
+++ b/src/projects/fullstack/src/shared/types.d.ts
@@ -38,61 +38,48 @@ export type Prettify<T> = T extends BuiltIn
 export type ServerAuth = typeof auth
 
 /**
- * Naming convention: `<service>:<operation><Suffix>`
+ * Naming convention: `<service>:<operation>:<suffix>`
  *
- * 1. Client API calls get a Rejection/Exception pair:
- *    `client:<operation>Rejection` - API responded (2xx) but returned an error
- *    `client:<operation>Exception` - error caught in the catch clause
+ * Suffix is one of:
+ *   `:exception` — code threw or a third-party call raised
+ *   `:rejection` — a third party returned a non-success response we treat as an
+ *                  error (e.g. Resend's API, Better Auth's handler returning 5xx)
  *
- * 2. Server-side async calls to external services also get a pair:
- *    `<service>:<operation>Rejection` - service responded but indicated failure
- *    `<service>:<operation>Exception` - error caught in the catch clause
- *
- * 3. Standalone error scenarios (less common) only get Exception:
- *    `<area>:<name>Exception` - catch-all or one-off error handler
+ * The DB only stores genuine errors. User-input failures (wrong password, bad
+ * file, expired token) are handled inline with a toast — they're not captured
+ * because the system is functioning correctly. Rejections originating on the
+ * server are captured server-side; the client never sends rejection data back.
+ * Hence every `client:*` context is `:exception` only.
  */
 export type ErrorContext =
   // Server
-  | 'hono:topLevelException'
-  | 'hono:rateLimitException'
-  | 'betterAuth:topLevelException'
-  | 'resend:sendSignUpVerificationEmailRejection'
-  | 'resend:sendSignUpVerificationEmailException'
-  | 'resend:sendResetPasswordEmailRejection'
-  | 'resend:sendResetPasswordEmailException'
-  | 'resend:sendChangeEmailRejection'
-  | 'resend:sendChangeEmailException'
-  | 'resend:sendDeleteAccountVerificationEmailRejection'
-  | 'resend:sendDeleteAccountVerificationEmailException'
-  | 'dbCleanup:purgeStaleRecordsException'
+  | 'hono:topLevel:exception'
+  | 'hono:rateLimit:exception'
+  | 'betterAuth:topLevel:exception'
+  | 'betterAuth:topLevel:rejection'
+  | 'resend:sendSignUpVerificationEmail:rejection'
+  | 'resend:sendSignUpVerificationEmail:exception'
+  | 'resend:sendResetPasswordEmail:rejection'
+  | 'resend:sendResetPasswordEmail:exception'
+  | 'resend:sendChangeEmail:rejection'
+  | 'resend:sendChangeEmail:exception'
+  | 'resend:sendDeleteAccountVerificationEmail:rejection'
+  | 'resend:sendDeleteAccountVerificationEmail:exception'
+  | 'dbCleanup:purgeStaleRecords:exception'
 
-  // Client
-  | 'client:topLevelException'
-  | 'client:signInRejection'
-  | 'client:signInException'
-  | 'client:signUpRejection'
-  | 'client:signUpException'
-  | 'client:signOutRejection'
-  | 'client:signOutException'
-  | 'client:resetPasswordRejection'
-  | 'client:resetPasswordException'
-  | 'client:requestPasswordResetRejection'
-  | 'client:requestPasswordResetException'
-  | 'client:changeEmailRejection'
-  | 'client:changeEmailException'
-  | 'client:changePasswordRejection'
-  | 'client:changePasswordException'
-  | 'client:avatarUploadRejection'
-  | 'client:avatarUploadException'
-  | 'client:avatarDeleteRejection'
-  | 'client:avatarDeleteException'
-  | 'client:passkeyAddRejection'
-  | 'client:passkeyAddException'
-  | 'client:passkeyDeleteRejection'
-  | 'client:passkeyDeleteException'
-  | 'client:deleteAccountRejection'
-  | 'client:deleteAccountException'
-  | 'client:passkeyListRejection'
-  | 'client:passkeyListException'
-  | 'client:passkeySignInRejection'
-  | 'client:passkeySignInException'
+  // Client (exceptions only — see header comment)
+  | 'client:topLevel:exception'
+  | 'client:signIn:exception'
+  | 'client:signUp:exception'
+  | 'client:signOut:exception'
+  | 'client:resetPassword:exception'
+  | 'client:requestPasswordReset:exception'
+  | 'client:changeEmail:exception'
+  | 'client:changePassword:exception'
+  | 'client:avatarUpload:exception'
+  | 'client:avatarDelete:exception'
+  | 'client:passkeyAdd:exception'
+  | 'client:passkeyDelete:exception'
+  | 'client:deleteAccount:exception'
+  | 'client:passkeyList:exception'
+  | 'client:passkeySignIn:exception'


### PR DESCRIPTION
Closes #31.

## Summary

The `errors` table now only stores genuine system errors. Wrong-password, validation 400s, expired tokens — all expected UX, no longer captured. The round-trip via `/api/client-error` is gone for rejections (server already had the data); the renamed `/api/capture` endpoint exists only for what only the client can see (catch-block exceptions, React error boundary).

## Architecture

- **Three-part schema** `<service>:<operation>:<suffix>` with lowercase `rejection` / `exception`. All `client:*:rejection` contexts dropped — rejections are server-owned.
- **Deep module** on each side. New `captureError` (server) and `useCaptureError` (client). One call replaces the `getDatabase` + `errorToObject` + `bestEffort` + `db.insert(errorsTable)` boilerplate that was duplicated in 5 places.
- **Better Auth gains 5xx coverage.** Previously only throws were captured; now `if (res.status >= 500)` inside the existing wrapper captures rejections too as `betterAuth:topLevel:rejection`.
- **Endpoint rename.** `/api/client-error` → `/api/capture` (the path reflects what it does, not who calls it). Hook rename `useLogClientError` → `useCaptureError` (Sentry's vocabulary; disambiguates from `createLogger`).
- **Skills updated** — `add-error-context`, `add-api-endpoint`, `add-feature` reflect the new schema, the `captureError` API, and the rule "rejections are server-owned, 4xx is not an error".

## What disappeared from call sites

Every async client call site lost its `if (error) logClientError(...:rejection)` branch — that path was capturing wrong-password and similar UX as errors. Avatar mutations stopped branching on `DetailedError` for the capture decision (server already knows server-owned failures).

Net: **−159 lines** across 22 files (375 deletions, 216 additions).

## Test plan

- [x] `bun run typecheck:server` clean
- [x] `bun run typecheck:shared` clean
- [x] `bun run typecheck:root` clean
- [x] `bun run typecheck:client` — same 26 errors as baseline (pre-existing missing `routeTree.gen`, auto-resolved at dev-time). No new errors from the refactor.
- [ ] Manual smoke: sign-in with wrong password → toast only, no `errors` row
- [ ] Manual smoke: sign-in with network offline → `client:signIn:exception` row appears
- [ ] Manual smoke: trigger a server throw → `hono:topLevel:exception` row appears
- [ ] Manual smoke: avatar upload with too-large file → toast only, no row